### PR TITLE
feat: add `axiosProxyConfig` option to the configuration

### DIFF
--- a/src/fcm.ts
+++ b/src/fcm.ts
@@ -10,6 +10,7 @@ const FCM_ENDPOINT = 'https://fcm.googleapis.com/fcm/send'
 export default async function registerFCM(gcm: Types.GcmData, config: Types.ClientConfig): Promise<Types.Credentials> {
     const keys = await createKeys()
     const response = await request<Types.FcmData>({
+        ...config.axiosConfig,
         url: FCM_SUBSCRIBE,
         method: 'POST',
         headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { LogLevels } from "./constants"
+import { AxiosRequestConfig } from 'axios'
 
 export interface Credentials {
     keys: Keys
@@ -89,6 +90,10 @@ export interface ClientConfig {
     logLevel?: keyof typeof LogLevels
     vapidKey?: string
     heartbeatIntervalMs?: number
+    axiosConfig?: Omit<
+      AxiosRequestConfig,
+      'url' | 'method' | 'headers' | 'data' | 'responseType'
+    >
 }
 
 export interface EventChangeCredentials {


### PR DESCRIPTION
Not sure if you accept PRs here, but since I had to fork this project to add a feature I need, I thought to contribute back.

This allows users to specify the proxy options to be passed to axios when doing FCM/GCM requests:

```ts
const instance = new PushReceiver({
  axiosProxyConfig: {
    proxy: {
      protocol: 'http',
      host: 'somehost',
      port: 1234,
      auth: {
        username: 'foo',
        password: 'bar',
      },
    },
  },
  // ...other options
})

```

I also fixed the signatures for the `doRegister` and `postRegister` functions.