### PR TITLE
refactor: add named export to client.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ interface ClientConfig {
 ### Node example
 
 ```javascript
-import PushReceiver from '@eneris/push-receiver'
+import { PushReceiver } from '@eneris/push-receiver'
 import { argv as parsedArgs } from 'yargs'
 
 if (!parsedArgs.senderId) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -443,3 +443,5 @@ export default class PushReceiver extends EventEmitter {
         }, serverApiKey)
     }
 }
+
+export { PushReceiver }


### PR DESCRIPTION
This makes it easier to work with this library in ESM projects.

Currently, when I import this library using...

```ts
import PushReceiver from '@eneris/push-receiver'
```

...with `moduleResolution` set to `Node` and `module` set to `ES2015` in the tsconfig.json, my project builds fine, but I get a `TypeError: PushReceiver is not a constructor` when I try to run it.

The workaround would be setting `moduleResolution` to `Node16` or `NodeNext` and do something like this, which is not ideal:

```ts
import _PushReceiver from '@eneris/push-receiver'
const PushReceiver = _PushReceiver.default
```

Using the named export I've added, everything just works:

```ts
import { PushReceiver } from '@eneris/push-receiver'
```