### PR TITLE
fix: clear heartbeat timeouts when the client is destroyed

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -150,6 +150,7 @@ export default class PushReceiver extends EventEmitter {
 
     public destroy = () => {
         clearTimeout(this.retryTimeout)
+        this.clearHeartbeat()
 
         if (this.socket) {
             this.socket.off('close', this.handleSocketClose)


### PR DESCRIPTION
If the `destroy` method is called on a client, it keeps trying to send a heartbeat after `heartbeatIntervalMs`, resulting in a `TypeError: Cannot read properties of null (reading 'write')` here:

https://github.com/Eneris/push-receiver/blob/a71ceaee715d162096bc478b8d680e44b12e966c/src/client.ts#L246-L249

This fix calls the `clearHeartbeat` method on destroy to prevent this error.