### PR TITLE
fix infinite loop on truncated message size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@eneris/push-receiver",
+    "name": "@koush/push-receiver",
     "version": "3.1.4",
     "description": "A module to subscribe to GCM/FCM and receive notifications within a node process.",
     "main": "dist/client.js",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -147,7 +147,7 @@ export default class Parser extends EventEmitter {
         // above to be mid-packet like: new ProtobufJS.BufferReader(this.data.slice(0, 1))
         if (incompleteSizePacket) {
             this.state = ProcessingState.MCS_SIZE
-            this.waitForData()
+            this.isWaitingForData = true
             return
         }
 


### PR DESCRIPTION
waitForData sets the `minBytesNeeded` to 0 because MCS_SIZE is a varint. since there's no constraint on that size, it immediately tries to parse again, resulting in an infinite loop.

the fix is to set the waitingForData flag again and wait for any data to come in before trying (and possibly failing) again.