### PR TITLE
Support FCM register using default VAPID

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -51,7 +51,7 @@ export default class PushReceiver extends EventEmitter {
             bundleId: 'receiver.push.com',
             chromeId: 'org.chromium.linux',
             chromeVersion: '94.0.4606.51',
-            vapidKey: '',
+            vapidKey: 'BDOU99-h67HcA6JeFXHbSNMu7e2yNNu3RzoMj8TM4W88jITfq7ZmPvIM1Iv-4_l2LxQcYwhqby2xGpWwzjfAnG4', // Default Firebase VAPID
             persistentIds: [],
             heartbeatIntervalMs: 5 * 60 * 1000, // 5 min
             ...config

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,7 +51,7 @@ export default class PushReceiver extends EventEmitter {
             bundleId: 'receiver.push.com',
             chromeId: 'org.chromium.linux',
             chromeVersion: '94.0.4606.51',
-            vapidKey: '', // Default Firebase VAPID
+            vapidKey: '',
             persistentIds: [],
             heartbeatIntervalMs: 5 * 60 * 1000, // 5 min
             ...config

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,7 +51,7 @@ export default class PushReceiver extends EventEmitter {
             bundleId: 'receiver.push.com',
             chromeId: 'org.chromium.linux',
             chromeVersion: '94.0.4606.51',
-            vapidKey: 'BDOU99-h67HcA6JeFXHbSNMu7e2yNNu3RzoMj8TM4W88jITfq7ZmPvIM1Iv-4_l2LxQcYwhqby2xGpWwzjfAnG4', // Default Firebase VAPID
+            vapidKey: '', // Default Firebase VAPID
             persistentIds: [],
             heartbeatIntervalMs: 5 * 60 * 1000, // 5 min
             ...config

--- a/src/fcm.ts
+++ b/src/fcm.ts
@@ -83,7 +83,7 @@ export async function registerFCM(gcmData: Types.GcmData, installation: Types.In
         body: JSON.stringify({
             web: {
                 // Include VAPID only if it's not default key, otherwise FCM registration will fail
-                ...config.vapidKey !== DEFAULT_VAPID ? { applicationPubKey: config.vapidKey } : {},
+                applicationPubKey: config.vapidKey || undefined,
                 auth: encodeBase64URL(keys.authSecret),
                 /**
                  * TODO

--- a/src/fcm.ts
+++ b/src/fcm.ts
@@ -8,6 +8,7 @@ const FCM_REGISTRATION = 'https://fcmregistrations.googleapis.com/v1/'
 const FCM_INSTALLATION = 'https://firebaseinstallations.googleapis.com/v1/'
 const AUTH_VERSION = 'FIS_v2'
 const SDK_VERSION = 'w:0.6.6'
+const DEFAULT_VAPID = 'BDOU99-h67HcA6JeFXHbSNMu7e2yNNu3RzoMj8TM4W88jITfq7ZmPvIM1Iv-4_l2LxQcYwhqby2xGpWwzjfAnG4'
 
 // TODO: FIXME it is optional to send it but better to implement proper heatbeat in the future
 const getEmptyHeatbeat = () => btoa(JSON.stringify({ heartbeats: [], version: 2 })).toString()
@@ -81,13 +82,14 @@ export async function registerFCM(gcmData: Types.GcmData, installation: Types.In
         },
         body: JSON.stringify({
             web: {
-                applicationPubKey: config.vapidKey,
+                // Include VAPID only if it's not default key, otherwise FCM registration will fail
+                ...config.vapidKey !== DEFAULT_VAPID ? { applicationPubKey: config.vapidKey } : {},
                 auth: encodeBase64URL(keys.authSecret),
                 /**
                  * TODO
                  * Shouldn't endpoint be migrated to v1 too??? But official JS module still uses the old one...
                  * https://firebase.google.com/docs/cloud-messaging/migrate-v1
-                 * Currently not working with 
+                 * Currently not working with
                  * Works - https://fcm.googleapis.com/fcm/send
                  * Does not work - https://fcm.googleapis.com/v1/projects/{projectId}/messages:send
                  */

--- a/src/fcm.ts
+++ b/src/fcm.ts
@@ -8,7 +8,6 @@ const FCM_REGISTRATION = 'https://fcmregistrations.googleapis.com/v1/'
 const FCM_INSTALLATION = 'https://firebaseinstallations.googleapis.com/v1/'
 const AUTH_VERSION = 'FIS_v2'
 const SDK_VERSION = 'w:0.6.6'
-const DEFAULT_VAPID = 'BDOU99-h67HcA6JeFXHbSNMu7e2yNNu3RzoMj8TM4W88jITfq7ZmPvIM1Iv-4_l2LxQcYwhqby2xGpWwzjfAnG4'
 
 // TODO: FIXME it is optional to send it but better to implement proper heatbeat in the future
 const getEmptyHeatbeat = () => btoa(JSON.stringify({ heartbeats: [], version: 2 })).toString()

--- a/src/gcm.ts
+++ b/src/gcm.ts
@@ -10,11 +10,6 @@ import { toBase64 } from './utils/base64'
 
 const REGISTER_URL = 'https://android.clients.google.com/c2dm/register3'
 const CHECKIN_URL = 'https://android.clients.google.com/checkin'
-const REGISTER_SERVER_KEY = [
-    0x04, 0x33, 0x94, 0xf7, 0xdf, 0xa1, 0xeb, 0xb1, 0xdc, 0x03, 0xa2, 0x5e, 0x15, 0x71, 0xdb, 0x48, 0xd3, 0x2e, 0xed, 0xed, 0xb2, 0x34, 0xdb, 0xb7, 0x47, 0x3a,
-    0x0c, 0x8f, 0xc4, 0xcc, 0xe1, 0x6f, 0x3c, 0x8c, 0x84, 0xdf, 0xab, 0xb6, 0x66, 0x3e, 0xf2, 0x0c, 0xd4, 0x8b, 0xfe, 0xe3, 0xf9, 0x76, 0x2f, 0x14, 0x1c, 0x63,
-    0x08, 0x6a, 0x6f, 0x2d, 0xb1, 0x1a, 0x95, 0xb0, 0xce, 0x37, 0xc0, 0x9c, 0x6e,
-]
 
 function parseLong(number: bigint, unsigned?: boolean | number, radix?: number): Long {
     return Long.fromString(number.toString(), unsigned, radix)
@@ -34,7 +29,7 @@ export async function checkIn(config: Types.ClientConfig): Promise<Types.GcmChec
         },
         body: prepareCheckinBuffer(config),
     })).arrayBuffer()
-    
+
 
     const AndroidCheckinResponse = Protos.checkin_proto.AndroidCheckinResponse
     const message = AndroidCheckinResponse.decode(new Uint8Array(body))
@@ -56,7 +51,7 @@ async function doRegister({ androidId, securityToken }: Types.GcmCheckinResponse
         app: 'org.chromium.linux',
         'X-subtype': appId,
         device: androidId,
-        sender: config.vapidKey, // toBase64(Buffer.from(REGISTER_SERVER_KEY)),
+        sender: config.vapidKey,
     })).toString()
 
     const response = await postRegister({ androidId, securityToken, body })

--- a/src/gcm.ts
+++ b/src/gcm.ts
@@ -6,7 +6,6 @@ import Protos from './protos'
 import Logger from './utils/logger'
 
 import type * as Types from './types'
-import { toBase64 } from './utils/base64'
 
 const REGISTER_URL = 'https://android.clients.google.com/c2dm/register3'
 const CHECKIN_URL = 'https://android.clients.google.com/checkin'

--- a/src/gcm.ts
+++ b/src/gcm.ts
@@ -51,7 +51,7 @@ async function doRegister({ androidId, securityToken }: Types.GcmCheckinResponse
         app: 'org.chromium.linux',
         'X-subtype': appId,
         device: androidId,
-        sender: config.vapidKey,
+        sender: config.vapidKey || 'BDOU99-h67HcA6JeFXHbSNMu7e2yNNu3RzoMj8TM4W88jITfq7ZmPvIM1Iv-4_l2LxQcYwhqby2xGpWwzjfAnG4',
     })).toString()
 
     const response = await postRegister({ androidId, securityToken, body })


### PR DESCRIPTION
The PR re-enables the ability to register using the default Firebase VAPID when no project specific VAPIDkey parameter is defined.  This seems to be required for receiving messages from Android projects where it appears the default VAPID key is used.  The issue here is in the registerFCM function, if you define `applicationPubKey` as the default VAPID, the registration will fail, however, if you simply exclude that parameter completely, the registration is successful and it appears to work with the default VAPID.

I have confirm that registration works with both my own project, and also with an external project that I do not control, although I have the required information to register.  After doing this I was able to receive push notifications as with previous versions.