### PR TITLE
Respect debug config

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -45,6 +45,7 @@ export default class PushReceiver extends EventEmitter {
     constructor(config: Types.ClientConfig) {
         super()
 
+        this.setDebug(config.debug)
         Logger.debug('constructor', config)
 
         this.#config = {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,14 +1,16 @@
 let debugEnabled = false
 
 export default {
-    setDebug: (enabled: boolean) => {
+    setDebug: (enabled?: boolean) => {
         debugEnabled = Boolean(enabled)
     },
     log: (...args: unknown[]): void => {
         console.log(...args)
     },
     debug: (...args: unknown[]): void => {
-        console.debug(...args)
+        if (debugEnabled) {
+            console.debug(...args)
+        }
     },
     warn: (...args: unknown[]): void => {
         console.warn(...args)


### PR DESCRIPTION
A new `debug: boolean` option was added in v4, but it doesn't look like the config is actually respected currently. Instead, all debug message are logged regardless of the config. This PR fixes that by checking the config before logging debug messages, and by properly configuring the logger upon instantiation.
