### PR TITLE
Remove extraneous console log

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -22,7 +22,6 @@ export default class ClassWithEmitter<EventMap extends EmitterEvents> {
 
     // @ts-expect-error - no reason TODO: Fixme
     emit<K extends keyof EventMap>(eventName: K, ...args: Parameters<EventMap[K]>) {
-        console.log('emit', eventName, ...args)
         this.#emitter.emit(eventName as string, ...args)
     }
 }


### PR DESCRIPTION
Looks like an extra `console.log` snuck into version 4.1.4. This should clean it up