### PR TITLE
End socket connection before destroying it

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -131,6 +131,7 @@ export default class PushReceiver extends Emitter<ClientEvents> {
 
         if (this.#socket) {
             this.#socket.removeAllListeners()
+            this.#socket.end()
             this.#socket.destroy()
             this.#socket = null
         }


### PR DESCRIPTION
It seems like the socket is kept open (receiving information), even after the `destroy`. The socket seems to stop receiving information only if `this.#socket.end()` is called previously.

I'm currently using this repo for a hobby project of mine and started facing this issue, so I made this change in a fork to use it myself.