### PR TITLE
fix: NAT-aware TCP keepalive + quieter benign-decrypt logging

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -420,7 +420,7 @@ export default class PushReceiver extends Emitter<ClientEvents> {
                     // NOTE(ibash) Periodically we're unable to decrypt notifications. In
                     // all cases we've been able to receive future notifications using the
                     // same keys. So, we silently drop this notification.
-                    Logger.warn('Message dropped as it could not be decrypted: ' + error.message)
+                    Logger.debug('Message dropped as it could not be decrypted: ' + error.message)
                     return
                 default:
                     throw error

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,7 +103,12 @@ export default class PushReceiver extends Emitter<ClientEvents> {
         this.#lastStreamIdReported = -1
 
         this.#socket = new tls.TLSSocket(null)
-        this.#socket.setKeepAlive(true)
+        // Probe after 30s idle instead of the OS default (7200s on Linux).
+        // Without an explicit initialDelay, half-open connections caused by
+        // residential NAT aging go undetected for 2+ hours. 30s makes a
+        // stalled socket trigger 'error'/'close' → existing retry logic
+        // within ~60-90s.
+        this.#socket.setKeepAlive(true, 30_000)
         this.#socket.on('connect', () => this.#handleSocketConnect())
         this.#socket.on('close', () => this.#handleSocketClose())
         this.#socket.on('error', (err) => this.#handleSocketError(err))


### PR DESCRIPTION
Hey! Found a couple of small but annoying bugs while running this on a Raspberry Pi behind a residential NAT, as the push client for a Homebridge Ring integration.

**1. TCP keepalive was way too patient**

`setKeepAlive(true)` without a delay just falls back to whatever the OS default is, which on Linux is a whopping 7200 seconds (2 hours). If your NAT table forgets about an idle connection in the meantime, which residential routers do constantly, you end up with a socket that looks "connected" but is actually dead. No errors, no pushes, nothing. I only caught this because motion alerts from my Ring cameras just stopped, for hours, while the client happily reported everything was fine.

Setting the delay explicitly to 30 seconds fixes it. The socket starts probing much sooner, so a dead connection gets flagged and reconnected within about a minute instead of sitting silently broken for half a day.

**2. Benign decrypt failures were logged way too loudly**

The comment right above this line already says it's a known, harmless situation ("we've been able to receive future notifications using the same keys"), but it was still logging at `warn`. Combine that with more frequent reconnects from fix #1 and my logs were getting spammed with warnings for something the code itself already treats as a non-issue. Bumped it to `debug` so it's still there if you want it, just not shouting for attention.

No behavior changes beyond that log level.

**Testing**

Ran this for several days on a real account and network with an aggressive NAT timeout. Before the fix, multi-hour silent delivery gaps were easy to reproduce. After, the socket recovers on its own within a minute or so. Happy to add a test asserting the `30_000` argument if that's useful, just let me know.