### PR TITLE
fix: keep credentials out of the debug log

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -16,8 +16,6 @@ import { Variables, MCSProtoTag } from './constants'
 
 import type * as Types from './types'
 
-const REDACTED = '[redacted]'
-
 export {
     Types
 }
@@ -37,31 +35,6 @@ interface ClientEvents {
     ON_READY: (data: void) => void
     ON_HEARTBEAT: (data: void) => void
 }
-
-// Credentials grant access to the push channel, so keep the secret parts out
-// of the log. What is left is enough to tell registrations apart and to see
-// when the installation token expires.
-const redactCredentials = (credentials: Types.Credentials) => ({
-    keys: {
-        privateKey: REDACTED,
-        publicKey: credentials.keys.publicKey,
-        authSecret: REDACTED,
-    },
-    gcm: {
-        ...credentials.gcm,
-        token: REDACTED,
-        securityToken: REDACTED,
-    },
-    fcm: {
-        token: REDACTED,
-        installation: {
-            ...credentials.fcm.installation,
-            token: REDACTED,
-            refreshToken: REDACTED,
-        },
-    },
-    config: credentials.config,
-})
 
 export default class PushReceiver extends Emitter<ClientEvents> {
     #config: Types.ClientConfig
@@ -214,8 +187,6 @@ export default class PushReceiver extends Emitter<ClientEvents> {
         })
 
         this.#config.credentials = credentials
-
-        Logger.debug('got credentials', redactCredentials(credentials))
 
         return this.#config.credentials
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,8 @@ import { Variables, MCSProtoTag } from './constants'
 
 import type * as Types from './types'
 
+const REDACTED = '[redacted]'
+
 export {
     Types
 }
@@ -35,6 +37,31 @@ interface ClientEvents {
     ON_READY: (data: void) => void
     ON_HEARTBEAT: (data: void) => void
 }
+
+// Credentials grant access to the push channel, so keep the secret parts out
+// of the log. What is left is enough to tell registrations apart and to see
+// when the installation token expires.
+const redactCredentials = (credentials: Types.Credentials) => ({
+    keys: {
+        privateKey: REDACTED,
+        publicKey: credentials.keys.publicKey,
+        authSecret: REDACTED,
+    },
+    gcm: {
+        ...credentials.gcm,
+        token: REDACTED,
+        securityToken: REDACTED,
+    },
+    fcm: {
+        token: REDACTED,
+        installation: {
+            ...credentials.fcm.installation,
+            token: REDACTED,
+            refreshToken: REDACTED,
+        },
+    },
+    config: credentials.config,
+})
 
 export default class PushReceiver extends Emitter<ClientEvents> {
     #config: Types.ClientConfig
@@ -188,7 +215,7 @@ export default class PushReceiver extends Emitter<ClientEvents> {
 
         this.#config.credentials = credentials
 
-        Logger.debug('got credentials', credentials)
+        Logger.debug('got credentials', redactCredentials(credentials))
 
         return this.#config.credentials
     }


### PR DESCRIPTION
## The problem

`registerIfNeeded()` logs the whole credentials object:

```ts
Logger.debug('got credentials', credentials)
```

That object contains everything needed to take over the push channel: the GCM `securityToken`, the FCM token, the installation auth token and its `refreshToken`, plus the web push `privateKey` and `authSecret`. With `debug: true` these land in whatever log the consumer writes — and those logs are exactly what people paste into bug reports.

I ran into this while debugging missing push notifications through homebridge-ring: turning on debug wrote a full set of credentials into `homebridge.log`, which then had to be truncated.

## What this PR changes

Redacts the secret fields and keeps what makes the line useful for debugging — `androidId`, `appId`, `fid`, the installation `createdAt`/`expiresIn`, the public key and the config metadata:

```
got credentials {
  keys: { privateKey: '[redacted]', publicKey: 'BHMK…', authSecret: '[redacted]' },
  gcm: { token: '[redacted]', androidId: '4655…', securityToken: '[redacted]', appId: 'wp:receiver.push.com#…' },
  fcm: { token: '[redacted]', installation: { token: '[redacted]', createdAt: 1788540966324, expiresIn: 604800000, refreshToken: '[redacted]', fid: 'edrN…' } },
  config: { bundleId: 'receiver.push.com', projectId: '…', vapidKey: '' }
}
```

`tsc --noEmit` and `eslint src/**/*.ts` are clean. No behaviour change beyond the log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVUFgtojQrWQcsoVMz5r6w
